### PR TITLE
fix(examples):  add service formatter

### DIFF
--- a/examples/basic-example/src/services/index.js
+++ b/examples/basic-example/src/services/index.js
@@ -1,11 +1,16 @@
 import { defineServices } from '@music163/tango-boot';
 
+// service 默认会提取响应中的 data 字段作为返回数据，此处需对不符合预期的原始请求响应做转换。
+const formatRes = (res) => ({ data: { ...res } });
+
 export default defineServices({
   list: {
     url: 'https://dog.ceo/api/breeds/list/all',
+    formatter: formatRes,
   },
 
   getBreed: {
     url: 'https://dog.ceo/api/breed/:breed/images/random',
+    formatter: formatRes,
   },
 });


### PR DESCRIPTION
### 问题描述
现在点击示例中的 「加载 dogs 示例列表」按钮，会产生报错。```Cannot read properties of undefined (reading 'message')```
原因是  request 请求方法中 https://github.com/NetEase/tango-boot/blob/1b4feea9ec4bb2474e451320665046213935f332/packages/request/src/request.ts#L69 默认提取了响应中的 data 字段，而示例请求的返回值中无 data 字段。

### 修改方法
将示例请求的响应做了包装